### PR TITLE
Update instructions adding APT repo

### DIFF
--- a/docs/content/doc/packages/debian.en-us.md
+++ b/docs/content/doc/packages/debian.en-us.md
@@ -31,7 +31,7 @@ The following examples use `apt`.
 To register the Debian registry add the url to the list of known apt sources:
 
 ```shell
-echo "deb https://gitea.example.com/api/packages/{owner}/debian {distribution} {component}" >> /etc/apt/sources.list
+echo "deb https://gitea.example.com/api/packages/{owner}/debian {distribution} {component}" | sudo tee -a /etc/apt/sources.list.d/gitea.list
 ```
 
 | Placeholder    | Description |
@@ -43,13 +43,13 @@ echo "deb https://gitea.example.com/api/packages/{owner}/debian {distribution} {
 If the registry is private, provide credentials in the url:
 
 ```shell
-echo "deb https://{username}:{password}@gitea.example.com/api/packages/{owner}/debian {distribution} {component}" >> /etc/apt/sources.list
+echo "deb https://{username}:{password}@gitea.example.com/api/packages/{owner}/debian {distribution} {component}" | sudo tee -a /etc/apt/sources.list.d/gitea.list
 ```
 
 The Debian registry files are signed with a PGP key which must be known to apt:
 
 ```shell
-curl https://gitea.example.com/api/packages/{owner}/debian/repository.key | sudo apt-key add -
+sudo curl https://gitea.example.com/api/packages/{owner}/debian/repository.key -o /etc/apt/trusted.gpg.d/gitea-{owner}.asc
 ```
 
 Afterwards update the local package index:

--- a/templates/package/content/debian.tmpl
+++ b/templates/package/content/debian.tmpl
@@ -4,8 +4,8 @@
 		<div class="ui form">
 			<div class="field">
 				<label>{{svg "octicon-terminal"}} {{.locale.Tr "packages.debian.registry"}}</label>
-				<div class="markup"><pre class="code-block"><code>curl {{AppUrl}}api/packages/{{$.PackageDescriptor.Owner.Name}}/debian/repository.key | sudo apt-key add -
-echo "deb {{AppUrl}}api/packages/{{$.PackageDescriptor.Owner.Name}}/debian &lt;distribution&gt; &lt;component&gt;" >> /etc/apt/sources.list
+				<div class="markup"><pre class="code-block"><code>sudo curl {{AppUrl}}api/packages/{{$.PackageDescriptor.Owner.Name}}/debian/repository.key -o /etc/apt/trusted.gpg.d/gitea-{{$.PackageDescriptor.Owner.Name}}.asc
+echo "deb {{AppUrl}}api/packages/{{$.PackageDescriptor.Owner.Name}}/debian &lt;distribution&gt; &lt;component&gt;" | sudo tee -a /etc/apt/sources.list.d/gitea.list
 sudo apt update</code></pre></div>
 				<p>{{.locale.Tr "packages.debian.registry.info" | Safe}}</p>
 			</div>


### PR DESCRIPTION
@KN4CK3R awesome and thanks for your work on this!

I do have some small recommendations:

Use of apt-key is deprecated and won't be available after Debian 11 and Ubuntu 22.04.
* For the packages description and docs, consider replacing:
`curl .../debian/repository.key | sudo apt-key add -`
* with
`sudo curl ..../debian/repository.key -o /etc/trusted.gpg.d/gitea-<repo owner>.asc`


Similarly, for instructions on adding the repo URLs to apt sources, consider using `/etc/apt/sources.list.d` directory instead of editing `/etc/apt/sources.list` file, but this is a preference for each user:
* Replace
`echo "deb https://{AppUrl}/debian {distribution} {component}" >> /etc/apt/sources.list`
* with
`echo "deb https://{AppUrl}/debian {distribution} {component}" | sudo tee /etc/apt/sources.list.d/gitea-{owner}.list`

or even have one single file for all Gitea repo sources and a line for each user repo.
* For adding Debian repo for user "foo":
`echo "deb .../api/packages/foo/debian bionic main" | sudo tee -a /etc/apt/sources.list.d/gitea.list`
* and then also adding another repo for user "bar":
`echo "deb .../api/packages/bar/debian bullseye main" | sudo tee -a /etc/apt/sources.list.d/gitea.list`
* Resulting file:
```
deb https://localhost/api/packages/foo/debian bionic main
deb https://localhost/api/packages/bar/debian bullseye main
```

Even if using `/etc/apt/sources.list` is kept, replace redirection (`>>`) with `| sudo tee`
